### PR TITLE
Use exists('##ModeChanged') to check for ModeChanged

### DIFF
--- a/autoload/tpipeline.vim
+++ b/autoload/tpipeline.vim
@@ -93,7 +93,7 @@ func tpipeline#initialize()
 		let s:is_nvim = 1
 	endif
 	let s:has_modechgd = 0
-	if has('patch-8.2.3430')
+	if exists('##ModeChanged')
 		let s:has_modechgd = 1
 	endif
 	let s:has_eval_stl = 0


### PR DESCRIPTION
Nvim's has() cannot check for 8.2.xxxx patches.