### PR TITLE
Don't start tpipeline when nvim is started in headless or embed mode

### DIFF
--- a/plugin/tpipeline.vim
+++ b/plugin/tpipeline.vim
@@ -1,4 +1,4 @@
-if exists('g:loaded_tpipeline') || empty($TMUX) || !(has('nvim') || has('job')) || has('gui_running')
+if exists('g:loaded_tpipeline') || empty($TMUX) || !(has('nvim') ? len(v:lua.vim.api.nvim_list_uis()) : has('job')) || has('gui_running')
 	finish
 endif
 let g:loaded_tpipeline = 1

--- a/plugin/tpipeline.vim
+++ b/plugin/tpipeline.vim
@@ -1,4 +1,4 @@
-if exists('g:loaded_tpipeline') || empty($TMUX) || !(has('nvim') ? len(v:lua.vim.api.nvim_list_uis()) : has('job')) || has('gui_running')
+if exists('g:loaded_tpipeline') || empty($TMUX) || !(has('nvim') ? len(nvim_list_uis()) : has('job')) || has('gui_running')
 	finish
 endif
 let g:loaded_tpipeline = 1


### PR DESCRIPTION
Using `nvim --headless +'autocmd User PackerComplete quitall' +PackerSync` to upgrade plugins let the tmux bar dirty so may be a good solution not starting tpipeline when in headless or embed mode.