### PR TITLE
fix: retain user tmux status

### DIFF
--- a/autoload/tpipeline.vim
+++ b/autoload/tpipeline.vim
@@ -130,8 +130,8 @@ endfunc
 
 func tpipeline#fork_job()
 	if g:tpipeline_restore
-		let s:restore_left = trim(system("tmux display-message -p '#{status-left}'"))
-		let s:restore_right = trim(system("tmux display-message -p '#{status-right}'"))
+		let s:restore_left = system("tmux display-message -p '#{status-left}'")
+		let s:restore_right = system("tmux display-message -p '#{status-right}'")
 	endif
 	let script = printf("while IFS='$\\n' read -r l; do echo \"$l\" > '%s'", s:tpipeline_filepath)
 	if g:tpipeline_usepane


### PR DESCRIPTION
This was introduced in the previous pull request https://github.com/vimpostor/vim-tpipeline/pull/43.
I don't see a reason for removing spaces from the user's tmux status automatically unless the user has asked for it.