### PR TITLE
Exposing a public function to access script variable `s:active`

### DIFF
--- a/autoload/tpipeline/state.vim
+++ b/autoload/tpipeline/state.vim
@@ -28,6 +28,10 @@ func tpipeline#state#toggle_frozen()
 	endif
 endfunc
 
+func tpipeline#state#is_active()
+	return s:active
+endfunc
+
 func tpipeline#state#restore()
 	let s:active = 0
 


### PR DESCRIPTION
Exposing a public function to access script variable s:active. This will help users determine if the current state of statusline. 

A simple use case will be setting the `last_status = 3` when statusline is not embedded with tmux.