### PR TITLE
Fix interfering with typing when clearing stl for lualine

### DIFF
--- a/autoload/tpipeline/lualine.vim
+++ b/autoload/tpipeline/lualine.vim
@@ -15,7 +15,12 @@ endfunc
 
 func tpipeline#lualine#clear_all_stl()
 	for i in range(1, tabpagewinnr(tabpagenr(), '$'))
-		noa call win_execute(win_getid(i), 'setlocal stl<')
+		noa let s = getwinvar(win_getid(i), '&stl')
+		" Resetting the statusline may interfere with typing in that window,
+		" check for current statusline value before resetting it.
+		if !empty(s) && s !=# '%#StatusLine#'
+			noa call win_execute(win_getid(i), 'setlocal stl<')
+		endif
 	endfor
 endfunc
 


### PR DESCRIPTION
I've come across a strange issue.

I am using lualine, telescope, and vim-tpipeline. I also enable tpipeline_clearstl since I use a global status line.

I've discovered that updating the statusline may interfere with typing in a window. This often happens for me in telescope. See the screen recording below. When trying to type "nvim he", the cursor jumps back when changing the statusline and you end up typing something else.

https://user-images.githubusercontent.com/16953692/236268068-7b114ab0-086d-440e-be64-b42a9068ba24.mov

I've narrowed this down to updating the statusline, even if we set it to the current value. Perhaps this is some peculiar neovim behavior, but I guess that would take a lot of time to figure this out. In any case, it wouldn't hurt checking the statusline value in this plugin to fix the problem.

