### PR TITLE
fix: more robust tmux style format

### DIFF
--- a/lua/tpipeline/main.lua
+++ b/lua/tpipeline/main.lua
@@ -19,20 +19,20 @@ function M.color(grp)
 	end
 	local st = ''
 	if vim.fn.synIDattr(id, 'bold') == '1' then
-		st = ',bold'
+		st = '#[bold]'
 		was_bold = true
 	elseif was_bold then
-		st = ',nobold'
+		st = '#[nobold]'
 		was_bold = false
 	end
 	if vim.fn.synIDattr(id, 'italic') == '1' then
-		st = st .. ',italics'
+		st = st .. '#[italics]'
 		was_italic = true
 	elseif was_italic then
-		st = st .. ',noitalics'
+		st = st .. '#[noitalics]'
 		was_italic = false
 	end
-	return string.format('#[fg=%s,bg=%s%s]', fg, bg, st)
+	return string.format('#[fg=%s]#[bg=%s]%s', fg, bg, st)
 end
 
 function M.update()


### PR DESCRIPTION
When rendering the tmux statusline, the current translated tmux style format `#[fg=...,bg=...,bold]` is not supported within tmux escape sequence (e.g. `#{?client_prefix,#[...]...,#[...]...}`).

However, the same behaviour can be achieved by changing the format into `#[fg=...]#[bg=...]#[bold]`.

I'm trying to achieve something similar to https://github.com/vimpostor/vim-tpipeline/pull/45#issuecomment-1407571469, thanks.