### PR TITLE
Fix non-refreshing on lualine changing to command mode

### DIFF
--- a/autoload/tpipeline.vim
+++ b/autoload/tpipeline.vim
@@ -37,7 +37,7 @@ func tpipeline#build_hooks()
 		if empty(g:tpipeline_statusline) && !g:tpipeline_tabline
 			if tpipeline#lualine#is_lualine()
 				au OptionSet statusline call tpipeline#lualine#delay_eval()
-				au ModeChanged * call tpipeline#lualine#fix_stl()
+				au ModeChanged * call tpipeline#lualine#delay_eval()
 				set laststatus=0
 			elseif g:tpipeline_clearstl
 				au OptionSet statusline if v:option_type == 'global' | call tpipeline#util#clear_stl() | endif


### PR DESCRIPTION
Bug:

1. Using Lualine + tpipeline, macos
2. When switching from NORMAL to COMMAND mode (by just pressing `:`) in most cases changes to status bar are not picked up by tpipeline. Only very rarely it picks up correctly.
3. When switching other modes I haven't noticed such behaviour, but I haven't tested that much.

Switching to delayed variant fixes all.

IMO, this is rather safe as practically doesn't change anything in logic but works better with race.