### PR TITLE
tpipeline_usepane: target the original tmux pane vim forked the job in

### DIFF
--- a/autoload/tpipeline.vim
+++ b/autoload/tpipeline.vim
@@ -192,7 +192,7 @@ func tpipeline#fork_job()
 		endif
 	endif
 	if g:tpipeline_usepane
-		let script .= "; tmux select-pane -T \"#[fill=${C:3}]#[align=left]$l#[align=right]$r\""
+		let script .= "; tmux select-pane -t \"$TMUX_PANE\" -T \"#[fill=${C:3}]#[align=left]$l#[align=right]$r\""
 	endif
 	let script .= "; " . g:tpipeline_refreshcmd . "; done"
 


### PR DESCRIPTION
This fixes a small bug I've experienced from the feature I added in https://github.com/vimpostor/vim-tpipeline/pull/22.

When using the tpipeline_usepane option, if someone switches tmux panes quickly after starting vim, namely before `tmux select-pane -T ...` can execute, it'll change the pane title of the current pane we're on. To prevent this from happening, we target the original pane by using $TMUX_PANE. This variable should exist in every tmux session, but if for some reason it's not present, tmux falls back to the current pane.