### PR TITLE
Fix type mismatch in Vim9 percentage parser

### DIFF
--- a/autoload/tpipeline/parse.vim
+++ b/autoload/tpipeline/parse.vim
@@ -36,9 +36,9 @@ def Parse(opt: string): string
 		elseif first ==# 'v'
 			return string(virtcol('.'))
 		elseif first ==# 'p'
-			return tpipeline#util#percentage()
+			return string(tpipeline#util#percentage())
 		elseif first ==# 'P'
-			return tpipeline#util#percentage() .. '%'
+			return string(tpipeline#util#percentage()) .. '%'
 		elseif first ==# '='
 			return '%='
 		elseif first ==# '%'

--- a/autoload/tpipeline/parse.vim
+++ b/autoload/tpipeline/parse.vim
@@ -38,7 +38,7 @@ def Parse(opt: string): string
 		elseif first ==# 'p'
 			return string(tpipeline#util#percentage())
 		elseif first ==# 'P'
-			return string(tpipeline#util#percentage()) .. '%'
+			return tpipeline#util#percentage() .. '%'
 		elseif first ==# '='
 			return '%='
 		elseif first ==# '%'


### PR DESCRIPTION
## Description

Fixes a Vim 9.1 type mismatch in the percentage statusline parser. #78 

`tpipeline#parse#Parse()` is declared to return a string, but the `%p` case are directly returning the numeric result of `tpipeline#util#percentage()`.

This causes Vim 9.1 to report:

```text
E1012: Type mismatch; expected string but got number
```

The percentage value is now explicitly converted to a string before being returned.

## Changes

* Convert `tpipeline#util#percentage()` to a string for `%p`.

## Testing

Tested with Vim 9.1 and confirmed that the type mismatch no longer occurs when using the percentage statusline items.